### PR TITLE
Fixes misaligned item render

### DIFF
--- a/src/openmods/gui/component/GuiComponentTab.java
+++ b/src/openmods/gui/component/GuiComponentTab.java
@@ -58,7 +58,7 @@ public class GuiComponentTab extends GuiComponentBox {
 		GL11.glEnable(GL12.GL_RESCALE_NORMAL);
 		itemRenderer.zLevel = zLevel + 50; // <- critical! Must be >= 50
 		itemRenderer.renderItemIntoGUI(minecraft.fontRenderer, minecraft.getTextureManager(), iconStack,
-				offsetX + x + 4, offsetY + y + 4);
+				offsetX + x + 3, offsetY + y + 3);
 		GL11.glDisable(GL12.GL_RESCALE_NORMAL);
 		GL11.glDisable(GL11.GL_LIGHTING);
 	}


### PR DESCRIPTION
When playing around with some things, I happened the notice the item
displayed is not exactly in the center-- 1x1 pixels off  (at least for
me lol). This fixes that.
