### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@
 // Variables
 ext.mod_version = '0.6'
 ext.mc_ver = '1.7.10'
-ext.forge_ver = '10.13.0.1180'
+ext.forge_ver = '10.13.0.1198'
 
 //================================================
 // Pre-execute


### PR DESCRIPTION
Forge versions prior to 1198 do not have materialCost variable in AnvilUpdateEvent.java
