### PR TITLE
Added support for FakeSlots and SyncableInventory

### DIFF
--- a/src/main/java/openmods/OpenMods.java
+++ b/src/main/java/openmods/OpenMods.java
@@ -7,6 +7,8 @@ import net.minecraftforge.common.config.Configuration;
 import openmods.config.properties.CommandConfig;
 import openmods.config.properties.ConfigProcessing;
 import openmods.entity.DelayedEntityLoadManager;
+import openmods.events.network.FakeSlotEventPacket;
+import openmods.events.network.FakeSlotServer;
 import openmods.fakeplayer.FakePlayerPool;
 import openmods.integration.Integration;
 import openmods.integration.modules.BuildCraftPipes;
@@ -51,7 +53,8 @@ public class OpenMods {
 	public void preInit(FMLPreInitializationEvent evt) {
 		SyncChannelHolder.ensureLoaded();
 
-		NetworkEventManager.INSTANCE.startRegistration();
+		NetworkEventManager.INSTANCE.startRegistration()
+				.register(FakeSlotEventPacket.class);
 
 		RpcCallDispatcher.INSTANCE.startRegistration()
 				.registerInterface(IRpcDirectionBitMap.class)
@@ -73,6 +76,8 @@ public class OpenMods {
 		MinecraftForge.EVENT_BUS.register(DropCapture.instance);
 
 		MinecraftForge.EVENT_BUS.register(BucketFillHandler.instance);
+
+		MinecraftForge.EVENT_BUS.register(FakeSlotServer.instance);
 
 		FMLCommonHandler.instance().bus().register(DelayedActionTickHandler.INSTANCE);
 

--- a/src/main/java/openmods/container/FakeSlot.java
+++ b/src/main/java/openmods/container/FakeSlot.java
@@ -1,0 +1,35 @@
+package openmods.container;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+// Fake slot - sometimes also called "Phantom" or "Ghost" slot. It does not
+// allow any items being taken out or placed in. Changing items in the
+// inventory is done manually to prevent actually using up an item etc. e.g.
+// BuildCraft uses the same system.
+public class FakeSlot extends Slot {
+	public FakeSlot(IInventory inventory, int slotIndex, int x, int y) {
+		super(inventory, slotIndex, x, y);
+	}
+
+	@Override
+	public boolean canTakeStack(EntityPlayer player) {
+		// Nope!
+		return false;
+	}
+
+	@Override
+	public boolean isItemValid(ItemStack stack) {
+		// Nope!
+		return false;
+	}
+
+	@Override
+	public int getSlotStackLimit() {
+		// This is not really relevant, but the reality is only 1 item per
+		// stack is ever allowed. We can be nice and communicate that.
+		return 1;
+	}
+}

--- a/src/main/java/openmods/events/network/FakeSlotEventPacket.java
+++ b/src/main/java/openmods/events/network/FakeSlotEventPacket.java
@@ -1,0 +1,62 @@
+package openmods.events.network;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import cpw.mods.fml.common.network.ByteBufUtils;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+import openmods.Log;
+import openmods.network.DimCoord;
+import openmods.network.event.EventDirection;
+import openmods.network.event.NetworkEvent;
+import openmods.network.event.NetworkEventMeta;
+
+@NetworkEventMeta(direction = EventDirection.C2S)
+public class FakeSlotEventPacket extends BlockEventPacket {
+	ItemStack stack;
+	int slot;
+
+	public FakeSlotEventPacket() {}
+
+	public FakeSlotEventPacket(ItemStack stack, int slot, DimCoord dimCoords) {
+		super(dimCoords.dimension, dimCoords.x, dimCoords.y, dimCoords.z);
+
+		this.slot = slot;
+		this.stack = stack;
+	}
+
+	@Override
+	protected void readFromStream(DataInput input) throws IOException {
+		super.readFromStream(input);
+		this.slot = input.readInt();
+		int length = input.readInt();
+
+		if (length > 0) {
+			byte[] data = new byte[length];
+			input.readFully(data, 0, length);
+
+			ItemStack stack = ByteBufUtils.readItemStack(Unpooled.copiedBuffer(data));
+			this.stack = stack;
+		}
+	}
+
+	@Override
+	protected void writeToStream(DataOutput output) throws IOException {
+		super.writeToStream(output);
+		output.writeInt(slot);
+
+		ByteBuf buffer = Unpooled.buffer();
+		ByteBufUtils.writeItemStack(buffer, stack);
+		byte[] data = buffer.array();
+
+		output.writeInt(data.length);
+		output.write(data);
+	}
+
+}

--- a/src/main/java/openmods/events/network/FakeSlotServer.java
+++ b/src/main/java/openmods/events/network/FakeSlotServer.java
@@ -1,0 +1,26 @@
+package openmods.events.network;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.tileentity.TileEntity;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import openmods.Log;
+import openmods.inventory.IFakeSlotListener;
+import openmods.inventory.IInventoryProvider;
+
+public class FakeSlotServer {
+	public static final FakeSlotServer instance = new FakeSlotServer();
+
+	@SubscribeEvent
+	public void onFakeSlotChange(FakeSlotEventPacket event) {
+		// This is being called on the server side everytime a client clicks on
+		// a Fake Slot.
+
+		// It grabs the IFakeSlotListener the GUI click was operating on
+		TileEntity te = event.getWorld().getTileEntity(event.xCoord, event.yCoord, event.zCoord);
+		if (!(te instanceof IFakeSlotListener)) { throw new UnsupportedOperationException("TileEntity does not implement IFakeSlotListener"); }
+
+		// And reports the slot change accordingly.
+		IFakeSlotListener listener = (IFakeSlotListener)te;
+		listener.onFakeSlotChange(event.slot, event.stack);
+	}
+}

--- a/src/main/java/openmods/gui/FakeGuiContainer.java
+++ b/src/main/java/openmods/gui/FakeGuiContainer.java
@@ -1,0 +1,65 @@
+package openmods.gui;
+
+import java.util.List;
+
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+import openmods.container.ContainerBase;
+import openmods.container.FakeSlot;
+import openmods.events.network.FakeSlotEventPacket;
+import openmods.network.DimCoord;
+import openmods.tileentity.OpenTileEntity;
+
+public abstract class FakeGuiContainer<T extends ContainerBase<?>> extends BaseGuiContainer {
+
+	public FakeGuiContainer(T container, int width, int height, String name) {
+		super(container, width, height, name);
+	}
+
+	// The current player clicked a slot on the GUI
+	protected void onFakeSlotClick(int index, Slot slot) {
+		// This only ever runs on the client side, so we can safely the local
+		// thePlayer and his current item.
+		ItemStack playerStack = mc.thePlayer.inventory.getItemStack();
+
+		// Create a copy of the itemstack the player is currently holding
+		// since we don't want to manipulate it.
+		ItemStack newStack = null;
+		if (playerStack != null) {
+			newStack = playerStack.copy();
+		}
+
+		// Wrap everything we need nicely in a NetworkEvent and send it to
+		// the server - he will actually change the inventory accordingly.
+		Object owner = getContainer().getOwner();
+		if (owner instanceof OpenTileEntity) {
+			DimCoord dimCoords = ((OpenTileEntity)owner).getDimCoords();
+			new FakeSlotEventPacket(newStack, index, dimCoords).sendToServer();
+		}
+	}
+
+	// Since the Fake Slots do not take items, we need to manually track when
+	// a player clicks a slot.
+	@Override
+	protected void mouseClicked(int x, int y, int button) {
+		super.mouseClicked(x, y, button);
+
+		List<Slot> slots = getContainer().inventorySlots;
+
+		x = x - guiLeft + 1;
+		y = y - guiTop + 1;
+
+		int index = 0;
+		for (Slot slot : slots) {
+			if (slot instanceof FakeSlot) {
+				if (x >= slot.xDisplayPosition && x < slot.xDisplayPosition + 18) {
+					if (y >= slot.yDisplayPosition && y < slot.yDisplayPosition + 18) {
+						onFakeSlotClick(index, slot);
+					}
+				}
+			}
+
+			index++;
+		}
+	}
+}

--- a/src/main/java/openmods/inventory/IFakeSlotListener.java
+++ b/src/main/java/openmods/inventory/IFakeSlotListener.java
@@ -1,0 +1,7 @@
+package openmods.inventory;
+
+import net.minecraft.item.ItemStack;
+
+public interface IFakeSlotListener {
+	public void onFakeSlotChange(int slot, ItemStack stack);
+}

--- a/src/main/java/openmods/sync/SyncableInventory.java
+++ b/src/main/java/openmods/sync/SyncableInventory.java
@@ -1,0 +1,61 @@
+package openmods.sync;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import openmods.api.IValueProvider;
+import openmods.inventory.GenericInventory;
+
+public class SyncableInventory extends GenericInventory implements ISyncableObject {
+
+	private boolean dirty = false;
+
+	public SyncableInventory(String name, boolean isInvNameLocalized, int size) {
+		super(name, isInvNameLocalized, size);
+	}
+
+	@Override
+	public boolean isDirty() {
+		return dirty;
+	}
+
+	@Override
+	public void markClean() {
+		dirty = false;
+	}
+
+	@Override
+	public void markDirty() {
+		dirty = true;
+	}
+
+	@Override
+	public void readFromStream(DataInputStream stream) throws IOException {
+		NBTTagCompound tag = CompressedStreamTools.readCompressed(stream);
+		readFromNBT(tag);
+	}
+
+	@Override
+	public void writeToStream(DataOutputStream stream) throws IOException {
+		NBTTagCompound tag = new NBTTagCompound();
+		writeToNBT(tag);
+		CompressedStreamTools.writeCompressed(tag, stream);
+	}
+
+	@Override
+	public void writeToNBT(NBTTagCompound nbt, String name) {
+		this.writeToNBT(nbt);
+	}
+
+	@Override
+	public void readFromNBT(NBTTagCompound nbt, String name) {
+		this.readFromNBT(nbt);
+	}
+
+}


### PR DESCRIPTION
"Fake", "Ghost" or "Phantom" slots are called that way because they
do not allow direct stack interaction as in vanilla, but behave differently
when clicked. This system is often used to set "filters" for items without
actually using up the item in the players hand.

Buildcraft does this by preventing the Slots from being manipulated as usual,
but instead sends a packet to the server containing the details of the click
and the hold item.

This pull requests replicates this mechanism and exposes the system via
FakeSlot, FakeGuiContainer and IFakeSlotListener.
It also includes a straight forward SyncableInventory implementation extending
GenericInventory.

A usage example for both can be seen in an upcoming pull request to OP-Addons.