### PR TITLE
Fix a NullPointerException that occurs with distant liquid sources

### DIFF
--- a/src/main/java/openmods/liquids/BucketFillHandler.java
+++ b/src/main/java/openmods/liquids/BucketFillHandler.java
@@ -59,6 +59,7 @@ public class BucketFillHandler {
 		if (evt.getResult() != Result.DEFAULT) return;
 
 		final RayTraceResult target = evt.getTarget();
+		if (target == null) return;
 		if (target.typeOfHit != RayTraceResult.Type.BLOCK) return;
 
 		TileEntity te = evt.getWorld().getTileEntity(target.getBlockPos());


### PR DESCRIPTION
Got this error:
`java.lang.NullPointerException: Unexpected error
	at openmods.liquids.BucketFillHandler.onBucketFill(BucketFillHandler.java:62)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_208_BucketFillHandler_onBucketFill_FillBucketEvent.invoke(.dynamic)`
I added a sanity check to ensure that the target isn't null before continuing